### PR TITLE
ClearLine on error exit, and clarify failure to fetch.

### DIFF
--- a/ff-get.js
+++ b/ff-get.js
@@ -69,6 +69,9 @@ function _reallyRead (args) {
   const ficInflate = use('fic-inflate')
   return ficInflate(deflatedFic, fetchAndSpin.withOpts({cacheBreak: false})).then(fic => {
     const filenameize = use('filenameize')
+    if (fic.words === 0) {
+        throw new Error(`${args.url} could not be retrieved.`);
+    }
     const filename = filenameize(fic.title) + '.fic.toml'
     const TOML = require('@iarna/toml')
     const fs = use('fs-promises')

--- a/ff.js
+++ b/ff.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict'
 require('@iarna/lib')('util', '.')
-
+const readline = require('readline');
 const onExit = require('signal-exit')
 const yargs = require('yargs')
 
@@ -133,6 +133,7 @@ let exited = false
 
 function errorHandler (err) {
   exited = true
+  readline.clearLine(process.stdout);
   if (argv.debug) {
     console.log(err.stack)
   } else if (err.code === 'ENOENT') {


### PR DESCRIPTION
The progress bar had previously been left on the screen (it looks like
it resets the cursor position to the begining of the line). This
results in the error message overwriting it giving errors like

  `An error occured: Cannot read property 'replace' of nullwn.org/works/1234567890`

In addition, this change also throws a new Error when the url results
in an empty fic object.

Fixes #2 